### PR TITLE
feat(qodo-bridge): Improve session process management and type safety

### DIFF
--- a/src/qodo-bridge.ts
+++ b/src/qodo-bridge.ts
@@ -19,6 +19,7 @@ export class QodoCommandBridge {
       threadId: sessionId,
       buffer: '',
       isActive: false,
+      process: undefined,
     };
 
     this.sessions.set(sessionId, session);
@@ -58,6 +59,9 @@ export class QodoCommandBridge {
           cwd: process.cwd(), // Use current working directory
         });
 
+        session.process = qodoProcess;
+        session.isActive = true;
+
         let responseBuffer = '';
         let errorBuffer = '';
         let hasResponded = false;
@@ -84,6 +88,9 @@ export class QodoCommandBridge {
         });
 
         qodoProcess.on('exit', (code) => {
+          session.isActive = false;
+          session.process = undefined;
+
           if (this.debug) {
             console.error(`[qodo-bridge] Process exited with code ${code}`);
             console.error(`[qodo-bridge] Full response: ${responseBuffer}`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import { ChildProcess } from 'child_process';
+
 // ACP Protocol Types
 // Based on https://agentclientprotocol.com
 
@@ -126,7 +128,7 @@ export interface ToolResult {
 export interface QodoSession {
   id: string;
   threadId: string;
-  process?: any; // Child process
+  process?: ChildProcess;
   buffer: string;
   isActive: boolean;
 }


### PR DESCRIPTION
Refactors the `QodoCommandBridge` to enhance type safety and fix a bug in session process handling.

- Updates `QodoSession` interface to use the specific `ChildProcess` type instead of `any` for the process property.
- Corrects the `sendMessage` method to properly assign the spawned child process to the session object.
- Implements state management by tracking `isActive` and clearing the process from the session upon exit.

This ensures that session cleanup and stop generation logic can correctly operate on the child process, preventing orphaned processes.