### PR TITLE
refactor(acp-server): Improve type safety with generic request handlers

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,10 @@ export interface ACPRequest {
   params?: any;
 }
 
+export interface ACPTypedRequest<T> extends Omit<ACPRequest, 'params'> {
+  params: T;
+}
+
 export interface ACPResponse {
   jsonrpc: '2.0';
   id: string | number;
@@ -99,6 +103,11 @@ export interface SendMessageResult {
   role: 'assistant';
   content: MessageContent[];
   metadata?: Record<string, any>;
+}
+
+export interface PromptParams {
+  sessionId: string;
+  prompt?: (string | TextContent)[];
 }
 
 // Progress notifications


### PR DESCRIPTION
Introduces a generic `ACPTypedRequest` interface to provide strong typing for ACP method parameters.

- Refactors `initialize`, `createThread`, and `sendMessage` handlers to use the new typed interface.
- Creates a new dedicated `handlePrompt` function to correctly manage `session/prompt` requests, separating its logic from `sendMessage`.
- Adds a `PromptParams` type to specifically handle the structure of prompt-based messages.

This change significantly improves the type safety of the server, reducing the reliance on `any` and preventing potential runtime errors by ensuring request parameters are correctly typed.